### PR TITLE
Security & Compatibility Update: Path traversal fixes, hardened model…

### DIFF
--- a/flashvsr_src/pipelines/flashvsr_full.py
+++ b/flashvsr_src/pipelines/flashvsr_full.py
@@ -264,7 +264,7 @@ class FlashVSRFullPipeline(BasePipeline):
         if context_tensor is None:
             if prompt_path is None:
                 raise ValueError("init_cross_kv: 需要提供 prompt_path 或 context_tensor 其一")
-            ctx = torch.load(prompt_path, map_location=self.device)
+            ctx = torch.load(prompt_path, map_location=self.device, weights_only=True)
         else:
             ctx = context_tensor
 

--- a/flashvsr_src/pipelines/flashvsr_tiny.py
+++ b/flashvsr_src/pipelines/flashvsr_tiny.py
@@ -244,7 +244,7 @@ class FlashVSRTinyPipeline(BasePipeline):
         if context_tensor is None:
             if prompt_path is None:
                 raise ValueError("init_cross_kv: 需要提供 prompt_path 或 context_tensor 其一")
-            ctx = torch.load(prompt_path, map_location=self.device)
+            ctx = torch.load(prompt_path, map_location=self.device, weights_only=True)
         else:
             ctx = context_tensor
 

--- a/flashvsr_src/pipelines/flashvsr_tiny_long.py
+++ b/flashvsr_src/pipelines/flashvsr_tiny_long.py
@@ -244,7 +244,7 @@ class FlashVSRTinyLongPipeline(BasePipeline):
         if context_tensor is None:
             if prompt_path is None:
                 raise ValueError("init_cross_kv: 需要提供 prompt_path 或 context_tensor 其一")
-            ctx = torch.load(prompt_path, map_location=self.device)
+            ctx = torch.load(prompt_path, map_location=self.device, weights_only=True)
         else:
             ctx = context_tensor
 

--- a/gimmvfi/generalizable_INR/flowformer/core/FlowFormer/common.py
+++ b/gimmvfi/generalizable_INR/flowformer/core/FlowFormer/common.py
@@ -39,7 +39,7 @@ def sampler_gaussian(latent, mean, std, image_size, point_num=25):
 
     dx = torch.linspace(-1, 1, int(point_num**0.5))
     dy = torch.linspace(-1, 1, int(point_num**0.5))
-    delta = torch.stack(torch.meshgrid(dy, dx), axis=-1).to(
+    delta = torch.stack(torch.meshgrid(dy, dx, indexing="ij"), axis=-1).to(
         mean.device
     )  # [B*H*W, point_num**0.5, point_num**0.5, 2]
     delta_3sigma = (
@@ -77,7 +77,7 @@ def sampler_gaussian_zy(
 
     dx = torch.linspace(-1, 1, int(point_num**0.5))
     dy = torch.linspace(-1, 1, int(point_num**0.5))
-    delta = torch.stack(torch.meshgrid(dy, dx), axis=-1).to(
+    delta = torch.stack(torch.meshgrid(dy, dx, indexing="ij"), axis=-1).to(
         mean.device
     )  # [B*H*W, point_num**0.5, point_num**0.5, 2]
     delta_3sigma = (
@@ -114,7 +114,7 @@ def sampler_gaussian(latent, mean, std, image_size, point_num=25, return_deltaXY
 
     dx = torch.linspace(-1, 1, int(point_num**0.5))
     dy = torch.linspace(-1, 1, int(point_num**0.5))
-    delta = torch.stack(torch.meshgrid(dy, dx), axis=-1).to(
+    delta = torch.stack(torch.meshgrid(dy, dx, indexing="ij"), axis=-1).to(
         mean.device
     )  # [B*H*W, point_num**0.5, point_num**0.5, 2]
     delta_3sigma = (
@@ -155,7 +155,7 @@ def sampler_gaussian_fix(latent, mean, image_size, point_num=49):
 
     dx = torch.linspace(-radius, radius, 2 * radius + 1)
     dy = torch.linspace(-radius, radius, 2 * radius + 1)
-    delta = torch.stack(torch.meshgrid(dy, dx), axis=-1).to(
+    delta = torch.stack(torch.meshgrid(dy, dx, indexing="ij"), axis=-1).to(
         mean.device
     )  # [B*H*W, point_num**0.5, point_num**0.5, 2]
 
@@ -191,7 +191,7 @@ def sampler_gaussian_fix_pyramid(
 
     dx = torch.linspace(-radius, radius, 2 * radius + 1)
     dy = torch.linspace(-radius, radius, 2 * radius + 1)
-    delta = torch.stack(torch.meshgrid(dy, dx), axis=-1).to(
+    delta = torch.stack(torch.meshgrid(dy, dx, indexing="ij"), axis=-1).to(
         mean.device
     )  # [B*H*W, point_num**0.5, point_num**0.5, 2]
 
@@ -244,7 +244,7 @@ def sampler_gaussian_pyramid(
 
     dx = torch.linspace(-1, 1, int(point_num**0.5))
     dy = torch.linspace(-1, 1, int(point_num**0.5))
-    delta = torch.stack(torch.meshgrid(dy, dx), axis=-1).to(
+    delta = torch.stack(torch.meshgrid(dy, dx, indexing="ij"), axis=-1).to(
         mean.device
     )  # [B*H*W, point_num**0.5, point_num**0.5, 2]
     delta_3sigma = (
@@ -334,7 +334,7 @@ def sampler_gaussian_fix_pyramid_MH(
 
     dx = torch.linspace(-radius, radius, 2 * radius + 1)
     dy = torch.linspace(-radius, radius, 2 * radius + 1)
-    delta = torch.stack(torch.meshgrid(dy, dx), axis=-1).to(
+    delta = torch.stack(torch.meshgrid(dy, dx, indexing="ij"), axis=-1).to(
         mean.device
     )  # [B*H*W, point_num**0.5, point_num**0.5, 2]
 
@@ -380,7 +380,7 @@ def sampler(feat, center, window_size):
     radius = window_size // 2
     dx = torch.linspace(-radius, radius, 2 * radius + 1)
     dy = torch.linspace(-radius, radius, 2 * radius + 1)
-    delta = torch.stack(torch.meshgrid(dy, dx), axis=-1).to(
+    delta = torch.stack(torch.meshgrid(dy, dx, indexing="ij"), axis=-1).to(
         center.device
     )  # [B*H*W, window_size, point_num**0.5, 2]
 
@@ -402,7 +402,7 @@ def retrieve_tokens(feat, center, window_size, sampler):
     radius = window_size // 2
     dx = torch.linspace(-radius, radius, 2 * radius + 1)
     dy = torch.linspace(-radius, radius, 2 * radius + 1)
-    delta = torch.stack(torch.meshgrid(dy, dx), axis=-1).to(
+    delta = torch.stack(torch.meshgrid(dy, dx, indexing="ij"), axis=-1).to(
         center.device
     )  # [B*H*W, point_num**0.5, point_num**0.5, 2]
 

--- a/gimmvfi/generalizable_INR/modules/fi_utils.py
+++ b/gimmvfi/generalizable_INR/modules/fi_utils.py
@@ -71,7 +71,7 @@ def resize(x, scale_factor):
 
 
 def coords_grid(batch, ht, wd):
-    coords = torch.meshgrid(torch.arange(ht), torch.arange(wd))
+    coords = torch.meshgrid(torch.arange(ht), torch.arange(wd), indexing="ij")
     coords = torch.stack(coords[::-1], dim=0).float()
     return coords[None].repeat(batch, 1, 1, 1)
 

--- a/gimmvfi/generalizable_INR/raft/corr.py
+++ b/gimmvfi/generalizable_INR/raft/corr.py
@@ -60,7 +60,7 @@ class BidirCorrBlock:
 
             dx = torch.linspace(-r, r, 2 * r + 1, device=coords0.device)
             dy = torch.linspace(-r, r, 2 * r + 1, device=coords0.device)
-            delta = torch.stack(torch.meshgrid(dy, dx), axis=-1)
+            delta = torch.stack(torch.meshgrid(dy, dx, indexing="ij"), axis=-1)
             delta_lvl = delta.view(1, 2 * r + 1, 2 * r + 1, 2)
 
             centroid_lvl_0 = coords0.reshape(batch * h1 * w1, 1, 1, 2) / 2**i
@@ -151,7 +151,7 @@ class CorrBlock:
             corr = self.corr_pyramid[i]
             dx = torch.linspace(-r, r, 2 * r + 1, device=coords.device)
             dy = torch.linspace(-r, r, 2 * r + 1, device=coords.device)
-            delta = torch.stack(torch.meshgrid(dy, dx), axis=-1)
+            delta = torch.stack(torch.meshgrid(dy, dx, indexing="ij"), axis=-1)
 
             centroid_lvl = coords.reshape(batch * h1 * w1, 1, 1, 2) / 2**i
             delta_lvl = delta.view(1, 2 * r + 1, 2 * r + 1, 2)

--- a/gimmvfi/generalizable_INR/raft/raft.py
+++ b/gimmvfi/generalizable_INR/raft/raft.py
@@ -9,18 +9,21 @@ from .corr import CorrBlock, AlternateCorrBlock
 from .utils.utils import bilinear_sampler, coords_grid, upflow8
 
 try:
-    autocast = torch.cuda.amp.autocast
-except:
-    # dummy autocast for PyTorch < 1.6
-    class autocast:
-        def __init__(self, enabled):
-            pass
-
-        def __enter__(self):
-            pass
-
-        def __exit__(self, *args):
-            pass
+    from torch import amp
+    def autocast(enabled):
+        return amp.autocast('cuda', enabled=enabled)
+except ImportError:
+    # Fallback for older PyTorch versions
+    try:
+        from torch.cuda.amp import autocast as legacy_autocast
+        def autocast(enabled):
+            return legacy_autocast(enabled=enabled)
+    except ImportError:
+        # Dummy autocast for very old PyTorch
+        class autocast:
+            def __init__(self, enabled): pass
+            def __enter__(self): pass
+            def __exit__(self, *args): pass
 
 
 class RAFT(nn.Module):

--- a/gimmvfi/generalizable_INR/raft/utils/utils.py
+++ b/gimmvfi/generalizable_INR/raft/utils/utils.py
@@ -82,7 +82,7 @@ def bilinear_sampler(img, coords, mode="bilinear", mask=False):
 
 def coords_grid(batch, ht, wd, device):
     coords = torch.meshgrid(
-        torch.arange(ht, device=device), torch.arange(wd, device=device)
+        torch.arange(ht, device=device), torch.arange(wd, device=device), indexing="ij"
     )
     coords = torch.stack(coords[::-1], dim=0).float()
     return coords[None].repeat(batch, 1, 1, 1)

--- a/server.py
+++ b/server.py
@@ -20,6 +20,12 @@ try:
         else:
             return web.json_response({"error": "no filename or path"}, status=400)
 
+        # Enforce that the file has a safe extension to prevent probing arbitrary system files
+        allowed_extensions = {'.mp4', '.webm', '.mkv', '.mov', '.avi', '.gif'}
+        ext = os.path.splitext(file_path)[1].lower()
+        if ext not in allowed_extensions:
+            return web.json_response({"error": "forbidden extension"}, status=403)
+
         if not os.path.exists(file_path):
             return web.json_response({"error": "file not found"}, status=404)
 
@@ -74,6 +80,9 @@ try:
             '.gif': 'image/gif',
         }
         ext = os.path.splitext(file_path)[1].lower()
+        if ext not in content_types:
+            return web.Response(status=403, text="Forbidden: Invalid file extension")
+
         content_type = content_types.get(ext, 'application/octet-stream')
 
         return web.FileResponse(file_path, headers={'Content-Type': content_type})

--- a/vsrfi_frames.py
+++ b/vsrfi_frames.py
@@ -66,6 +66,7 @@ class VSRFIFramesNode:
                 "frames_per_chunk": ("INT", {"default": 100, "min": 1, "max": 100000, "tooltip": "Number of frames to process at a time"}),
                 "max_tile_kilopixels": ("INT", {"default": 0, "min": 0, "max": 100000, "tooltip": "Used for VSR tiling. Set as high as your VRAM allows. 0 = auto-calculate based on available VRAM."}),
                 "max_gimm_kilopixels": ("INT", {"default": 0, "min": 0, "max": 100000, "tooltip": "GIMM-VFI only. Max kilopixels for flow estimation. 0 = auto."}),
+                "compatibility_mode": ("BOOLEAN", {"default": False, "tooltip": "Force PyTorch native attention (slower but more compatible with older GPUs)"}),
             }
         }
 
@@ -73,19 +74,27 @@ class VSRFIFramesNode:
     FUNCTION = "process"
     CATEGORY = "video"
 
-    def process(self, frames, scale, interpolation_factor, vfi_method, frames_per_chunk, max_tile_kilopixels, max_gimm_kilopixels):
+    def _get_device(self):
+        """Get the appropriate device using ComfyUI's model management if possible."""
+        if comfy is not None:
+            return comfy.model_management.get_torch_device()
+        return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    def process(self, frames, scale, interpolation_factor, vfi_method, frames_per_chunk, max_tile_kilopixels, max_gimm_kilopixels, compatibility_mode=False):
         # Unload all ComfyUI models (e.g. video generation) and free VRAM before loading our models
         if comfy is not None:
             comfy.model_management.unload_all_models()
         clean_vram()
 
+        # Set attention compatibility mode
+        wan_video_dit.set_compatibility_mode(compatibility_mode)
         # Reset attention logging so we log which backend is used for this run
         wan_video_dit.reset_attention_logging()
 
         # Download models if needed
         download_models_if_needed()
 
-        device = "cuda:0"
+        device = self._get_device()
 
         N, h, w, c = frames.shape
         print(f"[DEBUG] Original input: {w}x{h}")
@@ -215,17 +224,31 @@ class VSRFIFramesNode:
 
         return torch.cat(all_upscaled, dim=0)
 
-    def _auto_max_input_pixels(self, scale, device):
-        """Estimate max input tile pixels from available VRAM and scale factor."""
+    def _auto_max_input_pixels(self, scale, num_frames, device):
+        """Estimate max input tile pixels from available VRAM, scale factor, and frame count."""
         free_bytes, total_bytes = torch.cuda.mem_get_info(device)
         free_gb = free_bytes / (1024**3)
+        
         # Reserve for model weights loaded during inference (DiT + TCDecoder)
-        model_inference_gb = 3.5
-        available_gb = max(0.5, free_gb - model_inference_gb) * 0.85
-        # Empirical: VRAM scales as input_pixels * scale^2.6
-        max_pixels = available_gb * 210000 / (scale ** 2.6)
+        is_compat = getattr(wan_video_dit, 'COMPATIBILITY_MODE', False)
+        model_inference_gb = 4.5 if is_compat else 3.5
+        
+        available_gb = max(0.2, free_gb - model_inference_gb) * 0.8
+        
+        # Efficiency factor: lower is safer. 
+        # Standard attention is hungrier.
+        base_factor = 80000 if is_compat else 150000
+        
+        # Penalty for high frame counts (Temporal Decoder overhead)
+        temporal_penalty = min(1.0, 30.0 / max(1, num_frames))
+        # Don't let it shrink to nothing, but give it a floor
+        temporal_penalty = max(0.4, temporal_penalty)
+        
+        max_pixels = available_gb * base_factor * temporal_penalty / (scale ** 2.6)
         equivalent_kpx = int(max_pixels * (scale ** 3) / 1000)
-        print(f"[INFO] Auto tile: max {max_pixels/1000:.0f}k input pixels for scale={scale}, equivalent max_tile_kilopixels={equivalent_kpx} (GPU {total_bytes/(1024**3):.1f}GB total, {free_gb:.1f}GB free, {available_gb:.1f}GB available)")
+        
+        mode_str = " (COMPAT MODE)" if is_compat else ""
+        print(f"[INFO] Auto tile{mode_str}: max {max_pixels/1000:.0f}k input pixels for scale={scale}, frames={num_frames}, equivalent max_tile_kilopixels={equivalent_kpx} (GPU {total_bytes/(1024**3):.1f}GB total, {free_gb:.1f}GB free, {available_gb:.1f}GB available)")
         return max_pixels
 
     def _upscale_chunk(self, pipe, frames, scale, max_tile_kilopixels, device):
@@ -233,7 +256,7 @@ class VSRFIFramesNode:
         N, h, w, c = frames.shape
 
         if max_tile_kilopixels == 0:
-            max_pixels = self._auto_max_input_pixels(scale, device)
+            max_pixels = self._auto_max_input_pixels(scale, N, device)
         else:
             max_pixels = max_tile_kilopixels * 1000 / (scale ** 3)
 

--- a/vsrfi_stream.py
+++ b/vsrfi_stream.py
@@ -163,13 +163,15 @@ class VSRFINode:
             return "Invalid video file: {}".format(video_path)
         return True
 
-    def process(self, video_path, output_path, scale, frames_per_chunk, max_tile_kilopixels, max_gimm_kilopixels, interpolation_factor, vfi_method="GIMM-VFI", skip_first_frames=0, frame_load_cap=0):
+    def process(self, video_path, output_path, scale, frames_per_chunk, max_tile_kilopixels, max_gimm_kilopixels, interpolation_factor, vfi_method="GIMM-VFI", skip_first_frames=0, frame_load_cap=0, compatibility_mode=False):
 
         # Unload all ComfyUI models (e.g. video generation) and free VRAM before loading our models
         if comfy is not None:
             comfy.model_management.unload_all_models()
         clean_vram()
 
+        # Set attention compatibility mode
+        wan_video_dit.set_compatibility_mode(compatibility_mode)
         # Reset attention logging so we log which backend is used for this run
         wan_video_dit.reset_attention_logging()
 
@@ -184,7 +186,7 @@ class VSRFINode:
         # Download models if needed
         download_models_if_needed()
 
-        device = "cuda:0"
+        device = self._get_device()
 
         # Default output directory: comfyui/output/VSRFI/
         default_output_dir = os.path.join(
@@ -233,11 +235,11 @@ class VSRFINode:
         
         pipe = FlashVSRTinyLongPipeline.from_model_manager(mm, device=device)
         pipe.TCDecoder = build_tcdecoder([512,256,128,128], device, dtype, 16+768)
-        pipe.TCDecoder.load_state_dict(torch.load(f"{model_path}/TCDecoder.ckpt", map_location=device), strict=False)
+        pipe.TCDecoder.load_state_dict(torch.load(f"{model_path}/TCDecoder.ckpt", map_location=device, weights_only=True), strict=False)
         pipe.TCDecoder.clean_mem()
         
         pipe.denoising_model().LQ_proj_in = Causal_LQ4x_Proj(3, 1536, 1).to(device, dtype=dtype)
-        pipe.denoising_model().LQ_proj_in.load_state_dict(torch.load(f"{model_path}/LQ_proj_in.ckpt", map_location="cpu"), strict=True)
+        pipe.denoising_model().LQ_proj_in.load_state_dict(torch.load(f"{model_path}/LQ_proj_in.ckpt", map_location="cpu", weights_only=True), strict=True)
         
         pipe.to(device, dtype=dtype)
         pipe.enable_vram_management(num_persistent_param_in_dit=None)
@@ -534,22 +536,36 @@ class VSRFINode:
 
         return chunk
 
-    def _auto_max_input_pixels(self, scale, device):
-        """Estimate max input tile pixels from available VRAM and scale factor."""
+    def _auto_max_input_pixels(self, scale, num_frames, device):
+        """Estimate max input tile pixels from available VRAM, scale factor, and frame count."""
         free_bytes, total_bytes = torch.cuda.mem_get_info(device)
         free_gb = free_bytes / (1024**3)
+        
         # Reserve for model weights loaded during inference (DiT + TCDecoder)
-        model_inference_gb = 3.5
-        available_gb = max(0.5, free_gb - model_inference_gb) * 0.85
-        # Empirical: VRAM scales as input_pixels * scale^2.6
-        max_pixels = available_gb * 210000 / (scale ** 2.6)
+        is_compat = getattr(wan_video_dit, 'COMPATIBILITY_MODE', False)
+        model_inference_gb = 4.5 if is_compat else 3.5
+        
+        available_gb = max(0.2, free_gb - model_inference_gb) * 0.8
+        
+        # Efficiency factor: lower is safer. 
+        # Standard attention is hungrier.
+        base_factor = 80000 if is_compat else 150000
+        
+        # Penalty for high frame counts (Temporal Decoder overhead)
+        temporal_penalty = min(1.0, 30.0 / max(1, num_frames))
+        # Don't let it shrink to nothing, but give it a floor
+        temporal_penalty = max(0.4, temporal_penalty)
+        
+        max_pixels = available_gb * base_factor * temporal_penalty / (scale ** 2.6)
         equivalent_kpx = int(max_pixels * (scale ** 3) / 1000)
-        print(f"[INFO] Auto tile: max {max_pixels/1000:.0f}k input pixels for scale={scale}, equivalent max_tile_kilopixels={equivalent_kpx} (GPU {total_bytes/(1024**3):.1f}GB total, {free_gb:.1f}GB free, {available_gb:.1f}GB available)")
+        
+        mode_str = " (COMPAT MODE)" if is_compat else ""
+        print(f"[INFO] Auto tile{mode_str}: max {max_pixels/1000:.0f}k input pixels for scale={scale}, frames={num_frames}, equivalent max_tile_kilopixels={equivalent_kpx} (GPU {total_bytes/(1024**3):.1f}GB total, {free_gb:.1f}GB free, {available_gb:.1f}GB available)")
         return max_pixels
 
     def upscale_chunk(self, pipe, frames, scale, max_tile_kilopixels, device):
         if max_tile_kilopixels == 0:
-            max_pixels = self._auto_max_input_pixels(scale, device)
+            max_pixels = self._auto_max_input_pixels(scale, frames.shape[0], device)
         else:
             max_pixels = max_tile_kilopixels * 1000 / (scale ** 3)
 
@@ -731,7 +747,7 @@ class VSRFINode:
 
         model_path = load_file_from_github_release("rife", "rife49.pth")
         model = IFNet(arch_ver="4.7")
-        model.load_state_dict(torch.load(model_path, map_location="cpu"))
+        model.load_state_dict(torch.load(model_path, map_location="cpu", weights_only=True))
         model.eval().to(device)
         return model
 


### PR DESCRIPTION
# Sec/Hardening 

## Path traversal & LFI protection & restricted file access
Added strict file extension validation to the video_info, view API endpoints in server.py
Server now allows  video/image extensions mp4/webm/mkv/mov/avi/gif, preventing potential LFI attacks that could be used to probe sensitive sys files.

## Model Loading Hardening
Safe tensor loading,  updated all instances of torch.load across the stream node, frames node, and the FlashVSR PLs  to use weights_only=True //  prevents arbitrary code that could could be embedded in malicious  ckpt/pth model files, as per best sec practices w/  PyTorch.

# Compat

## ComfyUI Hardware Compatibility
Dynamic device resolution, replaced hardcoded cuda:0 strings with dynamic device detection using comfy.model_management.get_torch_device() //  ensuring nodes work correctly on multi-gpu setups and noncuda environments (like mac/mps).
attention compat mode, added a new compatibility_mode toggle to the VSRFI and VSRFI (Frames) nodes.
  * When enabled, it forces the DiT model to use standard PyTorch attention (sdpa) instead of specialized kernels (like flashattention), providing a reliable fallback for users on older gpus, (e.g., gtx-10XX series,  like the  gtx-1030   which I have in one of my machines, even though it is edge-case. for completeness sake)  or environments with incompatible triton/cuda configurations (less edge case) 

# Future proofing

## PyTorch modernization
Switched to modern autocast, updated the raft implementation to use the non-deprecated torch.amp.autocast('cuda', ...) syntax, replacing the older torch.cuda.amp calls.
Meshgrid warns,  fixed multiple UserWarning and FutureWarning messages by adding the explicit indexing='ij' argument to all torch.meshgrid calls. This ensures identical coordinate behavior in future PyTorch versions where this argument will become mandatory.

# Utility

## Maintenance & Stability
Memory mgmt, adjusted the placement of clean_vram() and soft_empty_cache() calls to ensure proper clean memory hand off between the upscaling (flashVSR) and interp  (gimm-vfi) phases, reducing the risk of oom errors on lower vram hardware.
last 3 feet OOM protection  temporal tiling logic,  preventing it from crashing during the final decoding phase of long videos which is especially common with sdpa  but also can occur with standard;  checks free VRAM ,  calculate baseline  and  calculates a temporal penalty  based on the frame count (starting at 30 frames) and then adds the 30% normal || 50% for sdpa reduction if compatibility mode is on. 


----Removed-----
*Crash Fix !!einops   added padding logic that prevents the node from crashing when processing non-standard resolutions ( eg,  test example  464x880 )*  **removed -  This caused weird banding.  So things look fine now,  but still get the crash on non-standard resolutions.** 

*removed tiling overlap adjustments from the pr,   that was not meant to be pushed*

*Also I apologize for the push fest.   switching between my fork and origin got weird  since comfy doesn't play nice with side by side testing.   I forgot why I usually don't do much with node repos..probably should just install another comfy insitance*

------
# Pre-Patch Run
-----
<details>
FlashVSR-v1.1 found at /home/robf/mounts/D/AI/ComfyUI/models/FlashVSR-v1.1
GIMM-VFI found at /home/robf/mounts/D/AI/ComfyUI/models/interpolation/gimm-vfi
[DEBUG] Original input: 624x656
[INFO] Processing 121 frames at 624x656 -> 1248x1312

 ███████╗██╗      █████╗ ███████╗██╗  ██╗██╗   ██╗███████╗█████╗
 ██╔════╝██║     ██╔══██╗██╔════╝██║  ██║██║   ██║██╔════╝██╔══██╗   ██╗
 █████╗  ██║     ███████║███████╗███████║╚██╗ ██╔╝███████╗███████║ ██████╗
 ██╔══╝  ██║     ██╔══██║╚════██║██╔══██║ ╚████╔╝ ╚════██║██╔═██║    ██╔═╝ 
 ██║     ███████╗██║  ██║███████║██║  ██║  ╚██╔╝  ███████║██║  ██║   ╚═╝
 ╚═╝     ╚══════╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝   ╚═╝   ╚══════╝╚═╝  ╚═╝

Using wan_video_dit from /home/robf/mounts/D/AI/ComfyUI/models/FlashVSR-v1.1/diffusion_pytorch_model_streaming_dmd.safetensors
[DEBUG] Upscaling 121 frames from 624x656 to 1248x1312
[DEBUG] Processing chunk 0-100 (100 frames)
[INFO] Auto tile: max 166k input pixels for scale=2, equivalent max_tile_kilopixels=1329 (GPU 9.6GB total, 9.1GB free, 4.8GB available)
[DEBUG] Tiling 624x656 into 2x2 grid with 32px overlap, output: 1248x1312
[DEBUG] Created 4 tiles
[DEBUG] Tile 1/4: 344x360 -> 688x720 = 495k output pixels at (0,0)
  0%|                                                                                                                                                                                                                | 0/11 [00:00<?, ?it/s][VSRFI] Using attention backend: SparseSageAttention (Triton) (with sparse mask)
[VSRFI] Available backends: SageAttention, SparseSageAttention (Triton), PyTorch SDPA (fallback)
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 11/11 [00:12<00:00,  1.13s/it]
[DEBUG] Tile 2/4: 344x360 -> 688x720 = 495k output pixels at (280,0)
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 11/11 [00:09<00:00,  1.10it/s]
[DEBUG] Tile 3/4: 344x360 -> 688x720 = 495k output pixels at (0,296)
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 11/11 [00:09<00:00,  1.11it/s]
[DEBUG] Tile 4/4: 344x360 -> 688x720 = 495k output pixels at (280,296)
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 11/11 [00:09<00:00,  1.10it/s]
[DEBUG] Tiled output: torch.Size([100, 1312, 1248, 3])
[DEBUG] Processing chunk 100-121 (21 frames)
[INFO] Auto tile: max 164k input pixels for scale=2, equivalent max_tile_kilopixels=1315 (GPU 9.6GB total, 9.1GB free, 4.7GB available)
[DEBUG] Tiling 624x656 into 2x2 grid with 32px overlap, output: 1248x1312
[DEBUG] Created 4 tiles
[DEBUG] Tile 1/4: 344x360 -> 688x720 = 495k output pixels at (0,0)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.15s/it]
[DEBUG] Tile 2/4: 344x360 -> 688x720 = 495k output pixels at (280,0)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.15s/it]
[DEBUG] Tile 3/4: 344x360 -> 688x720 = 495k output pixels at (0,296)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.15s/it]
[DEBUG] Tile 4/4: 344x360 -> 688x720 = 495k output pixels at (280,296)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  2.15s/it]
[DEBUG] Tiled output: torch.Size([21, 1312, 1248, 3])
[INFO] Interpolating 121 frames by 4x using GIMM-VFI
[DEBUG] VFI ds_factor: 0.7500 (1248x1312 padded to 1248x1312, downscaled to 936x984 = 921k pixels)
/home/robf/mounts/D/AI/ComfyUI/custom_nodes/VSRFI-ComfyUI/gimmvfi/generalizable_INR/raft/raft.py:121: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  with autocast(enabled=self.args.mixed_precision):
/home/robf/mounts/D/AI/ComfyUI/custom_nodes/VSRFI-ComfyUI/gimmvfi/generalizable_INR/raft/raft.py:132: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  with autocast(enabled=self.args.mixed_precision):
/home/robf/mounts/D/AI/ComfyUI/venv/lib64/python3.14/site-packages/torch/functional.py:505: UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument. (Triggered internally at /pytorch/aten/src/ATen/native/TensorShape.cpp:4381.)
  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]
/home/robf/mounts/D/AI/ComfyUI/custom_nodes/VSRFI-ComfyUI/gimmvfi/generalizable_INR/raft/raft.py:149: FutureWarning: `torch.cuda.amp.autocast(args...)` is deprecated. Please use `torch.amp.autocast('cuda', args...)` instead.
  with autocast(enabled=self.args.mixed_precision):
[INFO] Output: 481 frames at 1248x1312
</details>

-----
# Patch Test Runs 1-4  
1 GIMM-VFI
2 RIFE
3 FILM
4 GIMM-VFI Compatibility Mode PyTorch SDPA attn) 
-----
<details>
FlashVSR-v1.1 found at /home/robf/mounts/D/AI/ComfyUI/models/FlashVSR-v1.1
GIMM-VFI found at /home/robf/mounts/D/AI/ComfyUI/models/interpolation/gimm-vfi
[DEBUG] Original input: 624x656
[INFO] Processing 33 frames at 624x656 -> 1248x1312

 ███████╗██╗      █████╗ ███████╗██╗  ██╗██╗   ██╗███████╗█████╗
 ██╔════╝██║     ██╔══██╗██╔════╝██║  ██║██║   ██║██╔════╝██╔══██╗   ██╗
 █████╗  ██║     ███████║███████╗███████║╚██╗ ██╔╝███████╗███████║ ██████╗
 ██╔══╝  ██║     ██╔══██║╚════██║██╔══██║ ╚████╔╝ ╚════██║██╔═██║    ██╔═╝ 
 ██║     ███████╗██║  ██║███████║██║  ██║  ╚██╔╝  ███████║██║  ██║   ╚═╝
 ╚═╝     ╚══════╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝   ╚═╝   ╚══════╝╚═╝  ╚═╝

Using wan_video_dit from /home/robf/mounts/D/AI/ComfyUI/models/FlashVSR-v1.1/diffusion_pytorch_model_streaming_dmd.safetensors
[DEBUG] Upscaling 33 frames from 624x656 to 1248x1312
[DEBUG] Processing chunk 0-33 (33 frames)
[INFO] Auto tile: max 165k input pixels for scale=2, equivalent max_tile_kilopixels=1322 (GPU 9.6GB total, 9.1GB free, 4.8GB available)
[DEBUG] Tiling 624x656 into 2x2 grid with 32px overlap, output: 1248x1312
[DEBUG] Created 4 tiles
[DEBUG] Tile 1/4: 344x360 -> 688x720 = 495k output pixels at (0,0)
  0%|                                                                                                                                                                                                                 | 0/3 [00:00<?, ?it/s][VSRFI] Using attention backend: SparseSageAttention (Triton) (with sparse mask)
[VSRFI] Available backends: SageAttention, SparseSageAttention (Triton), PyTorch SDPA (fallback)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.28s/it]
[DEBUG] Tile 2/4: 344x360 -> 688x720 = 495k output pixels at (280,0)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.22s/it]
[DEBUG] Tile 3/4: 344x360 -> 688x720 = 495k output pixels at (0,296)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.23s/it]
[DEBUG] Tile 4/4: 344x360 -> 688x720 = 495k output pixels at (280,296)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.23s/it]
[DEBUG] Tiled output: torch.Size([33, 1312, 1248, 3])
[INFO] Interpolating 33 frames by 4x using GIMM-VFI
[DEBUG] VFI ds_factor: 0.7500 (1248x1312 padded to 1248x1312, downscaled to 936x984 = 921k pixels)
[DEBUG] VFI ds_factor: 0.7500 (1248x1312 padded to 1248x1312, downscaled to 936x984 = 921k pixels)
[INFO] Output: 129 frames at 1248x1312
 ███████╗██╗      █████╗ ███████╗██╗  ██╗██╗   ██╗███████╗█████╗
 ██╔════╝██║     ██╔══██╗██╔════╝██║  ██║██║   ██║██╔════╝██╔══██╗   ██╗
 █████╗  ██║     ███████║███████╗███████║╚██╗ ██╔╝███████╗███████║ ██████╗
 ██╔══╝  ██║     ██╔══██║╚════██║██╔══██║ ╚████╔╝ ╚════██║██╔═██║    ██╔═╝ 
 ██║     ███████╗██║  ██║███████║██║  ██║  ╚██╔╝  ███████║██║  ██║   ╚═╝
 ╚═╝     ╚══════╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝   ╚═╝   ╚══════╝╚═╝  ╚═╝

Using wan_video_dit from /home/robf/mounts/D/AI/ComfyUI/models/FlashVSR-v1.1/diffusion_pytorch_model_streaming_dmd.safetensors
got prompt
[DEBUG] Upscaling 33 frames from 624x656 to 1248x1312
[DEBUG] Processing chunk 0-33 (33 frames)
[INFO] Auto tile: max 163k input pixels for scale=2, equivalent max_tile_kilopixels=1300 (GPU 9.6GB total, 9.0GB free, 4.7GB available)
[DEBUG] Tiling 624x656 into 2x2 grid with 32px overlap, output: 1248x1312
[DEBUG] Created 4 tiles
[DEBUG] Tile 1/4: 344x360 -> 688x720 = 495k output pixels at (0,0)
  0%|                                                                                                                                                                                                                 | 0/3 [00:00<?, ?it/s][VSRFI] Using attention backend: SparseSageAttention (Triton) (with sparse mask)
[VSRFI] Available backends: SageAttention, SparseSageAttention (Triton), PyTorch SDPA (fallback)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.24s/it]
[DEBUG] Tile 2/4: 344x360 -> 688x720 = 495k output pixels at (280,0)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.23s/it]
[DEBUG] Tile 3/4: 344x360 -> 688x720 = 495k output pixels at (0,296)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.23s/it]
[DEBUG] Tile 4/4: 344x360 -> 688x720 = 495k output pixels at (280,296)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.23s/it]
[DEBUG] Tiled output: torch.Size([33, 1312, 1248, 3])
[INFO] Interpolating 33 frames by 2x using RIFE
[INFO] Output: 65 frames at 1248x1312
Prompt executed in 53.06 seconds
FlashVSR-v1.1 found at /home/robf/mounts/D/AI/ComfyUI/models/FlashVSR-v1.1
GIMM-VFI found at /home/robf/mounts/D/AI/ComfyUI/models/interpolation/gimm-vfi
[DEBUG] Original input: 624x656
[INFO] Processing 33 frames at 624x656 -> 1248x1312

 ███████╗██╗      █████╗ ███████╗██╗  ██╗██╗   ██╗███████╗█████╗
 ██╔════╝██║     ██╔══██╗██╔════╝██║  ██║██║   ██║██╔════╝██╔══██╗   ██╗
 █████╗  ██║     ███████║███████╗███████║╚██╗ ██╔╝███████╗███████║ ██████╗
 ██╔══╝  ██║     ██╔══██║╚════██║██╔══██║ ╚████╔╝ ╚════██║██╔═██║    ██╔═╝ 
 ██║     ███████╗██║  ██║███████║██║  ██║  ╚██╔╝  ███████║██║  ██║   ╚═╝
 ╚═╝     ╚══════╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝   ╚═╝   ╚══════╝╚═╝  ╚═╝

Using wan_video_dit from /home/robf/mounts/D/AI/ComfyUI/models/FlashVSR-v1.1/diffusion_pytorch_model_streaming_dmd.safetensors
[DEBUG] Upscaling 33 frames from 624x656 to 1248x1312
[DEBUG] Processing chunk 0-33 (33 frames)
[INFO] Auto tile: max 160k input pixels for scale=2, equivalent max_tile_kilopixels=1277 (GPU 9.6GB total, 8.9GB free, 4.6GB available)
[DEBUG] Tiling 624x656 into 2x2 grid with 32px overlap, output: 1248x1312
[DEBUG] Created 4 tiles
[DEBUG] Tile 1/4: 344x360 -> 688x720 = 495k output pixels at (0,0)
  0%|                                                                                                                                                                                                                 | 0/3 [00:00<?, ?it/s][VSRFI] Using attention backend: SparseSageAttention (Triton) (with sparse mask)
[VSRFI] Available backends: SageAttention, SparseSageAttention (Triton), PyTorch SDPA (fallback)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.23s/it]
[DEBUG] Tile 2/4: 344x360 -> 688x720 = 495k output pixels at (280,0)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.23s/it]
[DEBUG] Tile 3/4: 344x360 -> 688x720 = 495k output pixels at (0,296)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.24s/it]
[DEBUG] Tile 4/4: 344x360 -> 688x720 = 495k output pixels at (280,296)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:03<00:00,  1.23s/it]
[DEBUG] Tiled output: torch.Size([33, 1312, 1248, 3])
[INFO] Interpolating 33 frames by 2x using FILM
Downloading: "https://github.com/styler00dollar/VSGAN-tensorrt-docker/releases/download/models/film_net_fp32.pt" to /home/robf/mounts/D/AI/ComfyUI/custom_nodes/comfyui-frame-interpolation/ckpts/film/film_net_fp32.pt

Failed! Trying another endpoint.
Downloading: "https://github.com/Fannovel16/ComfyUI-Frame-Interpolation/releases/download/models/film_net_fp32.pt" to /home/robf/mounts/D/AI/ComfyUI/custom_nodes/comfyui-frame-interpolation/ckpts/film/film_net_fp32.pt

Failed! Trying another endpoint.
Downloading: "https://github.com/dajes/frame-interpolation-pytorch/releases/download/v1.0.0/film_net_fp32.pt" to /home/robf/mounts/D/AI/ComfyUI/custom_nodes/comfyui-frame-interpolation/ckpts/film/film_net_fp32.pt

100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 132M/132M [00:01<00:00, 114MB/s]
/home/robf/mounts/D/AI/ComfyUI/venv/lib64/python3.14/site-packages/torch/nn/modules/module.py:1787: UserWarning: Using padding='same' with even kernel lengths and odd dilation may require a zero-padded copy of the input be created (Triggered internally at /pytorch/aten/src/ATen/native/Convolution.cpp:1025.)
  return forward_call(*args, **kwargs)
[INFO] Output: 65 frames at 1248x1312
Prompt executed in 80.87 seconds
got prompt
FlashVSR-v1.1 found at /home/robf/mounts/D/AI/ComfyUI/models/FlashVSR-v1.1
GIMM-VFI found at /home/robf/mounts/D/AI/ComfyUI/models/interpolation/gimm-vfi
[DEBUG] Original input: 624x656
[INFO] Processing 33 frames at 624x656 -> 1248x1312

 ███████╗██╗      █████╗ ███████╗██╗  ██╗██╗   ██╗███████╗█████╗
 ██╔════╝██║     ██╔══██╗██╔════╝██║  ██║██║   ██║██╔════╝██╔══██╗   ██╗
 █████╗  ██║     ███████║███████╗███████║╚██╗ ██╔╝███████╗███████║ ██████╗
 ██╔══╝  ██║     ██╔══██║╚════██║██╔══██║ ╚████╔╝ ╚════██║██╔═██║    ██╔═╝ 
 ██║     ███████╗██║  ██║███████║██║  ██║  ╚██╔╝  ███████║██║  ██║   ╚═╝
 ╚═╝     ╚══════╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝   ╚═╝   ╚══════╝╚═╝  ╚═╝

Using wan_video_dit from /home/robf/mounts/D/AI/ComfyUI/models/FlashVSR-v1.1/diffusion_pytorch_model_streaming_dmd.safetensors
[DEBUG] Upscaling 33 frames from 624x656 to 1248x1312
[DEBUG] Processing chunk 0-33 (33 frames)
[INFO] Auto tile: max 160k input pixels for scale=2, equivalent max_tile_kilopixels=1277 (GPU 9.6GB total, 8.9GB free, 4.6GB available)
[DEBUG] Tiling 624x656 into 2x2 grid with 32px overlap, output: 1248x1312
[DEBUG] Created 4 tiles
[DEBUG] Tile 1/4: 344x360 -> 688x720 = 495k output pixels at (0,0)
  0%|                                                                                                                                                                                                                 | 0/3 [00:00<?, ?it/s][VSRFI] Using attention backend: PyTorch SDPA (dense fallback) (with sparse mask)
[VSRFI] Available backends: SageAttention, SparseSageAttention (Triton), PyTorch SDPA (fallback)
[VSRFI] Compatibility mode ENABLED - using PyTorch native attention
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:04<00:00,  1.48s/it]
[DEBUG] Tile 2/4: 344x360 -> 688x720 = 495k output pixels at (280,0)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:04<00:00,  1.49s/it]
[DEBUG] Tile 3/4: 344x360 -> 688x720 = 495k output pixels at (0,296)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:04<00:00,  1.49s/it]
[DEBUG] Tile 4/4: 344x360 -> 688x720 = 495k output pixels at (280,296)
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:04<00:00,  1.48s/it]
[DEBUG] Tiled output: torch.Size([33, 1312, 1248, 3])
[INFO] Interpolating 33 frames by 2x using GIMM-VFI
[DEBUG] VFI ds_factor: 0.7500 (1248x1312 padded to 1248x1312, downscaled to 936x984 = 921k pixels)
</details>